### PR TITLE
Implement personalization top tracks + top artists

### DIFF
--- a/core/shared/src/main/scala/io/scarman/spotify/Spotify.scala
+++ b/core/shared/src/main/scala/io/scarman/spotify/Spotify.scala
@@ -4,7 +4,8 @@ package spotify
 import com.softwaremill.sttp._
 import io.scarman.spotify.auth.ClientCredentials
 import io.scarman.spotify.http.Authorization
-import io.scarman.spotify.request.{BaseAlbumType, Categories, CategoryPlaylists, Search}
+import io.scarman.spotify.request.{BaseAlbumType, Categories, CategoryPlaylists, Search, TimeRange}
+import io.scarman.spotify.request.TimeRange.MediumTerm
 import scribe.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,6 +35,10 @@ class Spotify(val auth: Authorization)(implicit val backend: SttpBackend[Future,
     Category(categoryId, country, locale)(auth, backend)
   def getCategoryPlaylists(categoryId: String, country: Option[String] = None, limit: Int = 20, offset: Int = 0): CategoryPlaylists =
     CategoryPlaylists(categoryId, country, limit, offset)(auth, backend)
+  def getUsersTopTracks(limit: Int = 20, offset: Int = 0, timeRange: TimeRange = MediumTerm): UsersTopTracks =
+    UsersTopTracks(limit, offset, timeRange)(auth, backend)
+  def getUsersTopArtists(limit: Int = 20, offset: Int = 0, timeRange: TimeRange = MediumTerm): UsersTopArtists =
+    UsersTopArtists(limit, offset, timeRange)(auth, backend)
 
   def search(q: String,
              cat: String,

--- a/core/shared/src/main/scala/io/scarman/spotify/package.scala
+++ b/core/shared/src/main/scala/io/scarman/spotify/package.scala
@@ -1,32 +1,36 @@
 package io.scarman
 
 package object spotify {
-  type Album         = request.Album
-  type Albums        = request.Albums
-  type Artist        = request.Artist
-  type Artists       = request.Artists
-  type ArtistAlbums  = request.ArtistAlbums
-  type AlbumTracks   = request.AlbumTracks
-  type AudioAnalysis = request.AudioAnalysis
-  type AudioFeatures = request.AudioFeatures
-  type Track         = request.Track
-  type Tracks        = request.Tracks
-  type Category      = request.Category
+  type Album           = request.Album
+  type Albums          = request.Albums
+  type Artist          = request.Artist
+  type Artists         = request.Artists
+  type ArtistAlbums    = request.ArtistAlbums
+  type AlbumTracks     = request.AlbumTracks
+  type AudioAnalysis   = request.AudioAnalysis
+  type AudioFeatures   = request.AudioFeatures
+  type Track           = request.Track
+  type Tracks          = request.Tracks
+  type Category        = request.Category
+  type UsersTopTracks  = request.UsersTopTracks
+  type UsersTopArtists = request.UsersTopArtists
 
-  val Album         = request.Album
-  val Albums        = request.Albums
-  val Artist        = request.Artist
-  val Artists       = request.Artists
-  val ArtistAlbums  = request.ArtistAlbums
-  val AlbumTracks   = request.AlbumTracks
-  val AudioAnalysis = request.AudioAnalysis
-  val AudioFeatures = request.AudioFeatures
-  val Track         = request.Track
-  val Tracks        = request.Tracks
-  val AlbumTypes    = request.AlbumTypes
-  val appears_on    = request.appears_on
-  val compilation   = request.compilation
-  val fullalbum     = request.fullalbum
-  val single        = request.single
-  val Category      = request.Category
+  val Album           = request.Album
+  val Albums          = request.Albums
+  val Artist          = request.Artist
+  val Artists         = request.Artists
+  val ArtistAlbums    = request.ArtistAlbums
+  val AlbumTracks     = request.AlbumTracks
+  val AudioAnalysis   = request.AudioAnalysis
+  val AudioFeatures   = request.AudioFeatures
+  val Track           = request.Track
+  val Tracks          = request.Tracks
+  val AlbumTypes      = request.AlbumTypes
+  val appears_on      = request.appears_on
+  val compilation     = request.compilation
+  val fullalbum       = request.fullalbum
+  val single          = request.single
+  val Category        = request.Category
+  val UsersTopTracks  = request.UsersTopTracks
+  val UsersTopArtists = request.UsersTopArtists
 }

--- a/core/shared/src/main/scala/io/scarman/spotify/request/TimeRange.scala
+++ b/core/shared/src/main/scala/io/scarman/spotify/request/TimeRange.scala
@@ -1,0 +1,21 @@
+package io.scarman.spotify.request
+
+sealed trait TimeRange { val name: String }
+
+object TimeRange {
+
+  /**
+    * Several years of data and including all new data as it becomes available
+    */
+  case object LongTerm extends TimeRange { val name = "long_term" }
+
+  /**
+    * Approximately the last 6 months of data
+    */
+  case object MediumTerm extends TimeRange { val name = "medium_term" }
+
+  /**
+    * Approximately the last 4 weeks of data
+    */
+  case object ShortTerm extends TimeRange { val name = "short_term" }
+}

--- a/core/shared/src/main/scala/io/scarman/spotify/request/UsersTopArtists.scala
+++ b/core/shared/src/main/scala/io/scarman/spotify/request/UsersTopArtists.scala
@@ -1,0 +1,31 @@
+package io.scarman.spotify.request
+
+import com.softwaremill.sttp.{SttpBackend, UriContext}
+import io.scarman.spotify.http.{Authorization, HttpRequest}
+import io.scarman.spotify.request.TimeRange.MediumTerm
+import io.scarman.spotify.response
+import io.scarman.spotify.response.Paging
+
+import scala.concurrent.Future
+
+/**
+  * @see https://developer.spotify.com/documentation/web-api/reference/personalization/get
+  *      -users-top-artists-and-tracks/
+  *
+  * @note Requires auth for a user with the scope `user-top-read`, which currently means
+  *       only using an instance of {@link AuthorizationCode}
+  * @param limit The number of entities to return. Default: 20. Minimum: 1.
+  *       Maximum: 50. For example: limit=2
+  * @param offset The index of the first entity to return. Default: 0 (i.e.,
+  *               the first track). Use with limit to get the next set of entities.
+  * @param timeRange Over what time frame the affinities are computed.
+  */
+case class UsersTopArtists(limit: Int = 20, offset: Int = 0, timeRange: TimeRange = MediumTerm)(implicit auth: Authorization,
+                                                                                                backend: SttpBackend[Future, Nothing])
+    extends HttpRequest[Paging[response.Artist]] {
+
+  lazy protected val reqUri = uri"$base/me/top/tracks"
+    .param("limit", limit.toString)
+    .param("offset", offset.toString)
+    .param("time_range", timeRange.name)
+}

--- a/core/shared/src/main/scala/io/scarman/spotify/request/UsersTopTracks.scala
+++ b/core/shared/src/main/scala/io/scarman/spotify/request/UsersTopTracks.scala
@@ -1,0 +1,31 @@
+package io.scarman.spotify.request
+
+import com.softwaremill.sttp.{SttpBackend, UriContext}
+import io.scarman.spotify.http.{Authorization, HttpRequest}
+import io.scarman.spotify.request.TimeRange.MediumTerm
+import io.scarman.spotify.response
+import io.scarman.spotify.response.Paging
+
+import scala.concurrent.Future
+
+/**
+  * @see https://developer.spotify.com/documentation/web-api/reference/personalization/get
+  *      -users-top-artists-and-tracks/
+  *
+  * @note Requires auth for a user with the scope `user-top-read`, which currently means
+  *       only using an instance of {@link AuthorizationCode}
+  * @param limit The number of entities to return. Default: 20. Minimum: 1.
+  *       Maximum: 50. For example: limit=2
+  * @param offset The index of the first entity to return. Default: 0 (i.e.,
+  *               the first track). Use with limit to get the next set of entities.
+  * @param timeRange Over what time frame the affinities are computed.
+  */
+case class UsersTopTracks(limit: Int = 20, offset: Int = 0, timeRange: TimeRange = MediumTerm)(implicit auth: Authorization,
+                                                                                               backend: SttpBackend[Future, Nothing])
+    extends HttpRequest[Paging[response.Track]] {
+
+  lazy protected val reqUri = uri"$base/me/top/tracks"
+    .param("limit", limit.toString)
+    .param("offset", offset.toString)
+    .param("time_range", timeRange.name)
+}


### PR DESCRIPTION
Personally I also need the Library, Playlist, and Recommendations 
endpoints, so I wanted to check in before I wrote them all up.

This is the first of the /me endpoints, I've confirmed it works hacking
around in the example app, but don't think there is a good way to test
it with the existing infra, because it requires an access token on
behalf of a user.

Obviously I could hard code an access/refresh token with the correct
scope, but that doesn't scale to the endpoints that make modifications.

Maybe we could use Wiremock to at least verify the TCP/JSON part of the
stack. I also noticed sttp has a test library, but couldn't tell if it
actually uses TCP or just mocks them.